### PR TITLE
Update setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -67,7 +67,7 @@ function get_source() {
         curl "$url" > "$tmpfile"
         mv "$tmpfile" "$tgz"
 
-        if echo "$md5 $tgz" | md5sum -c --quiet
+        if echo "$md5  $tgz" | md5sum -c --quiet
         then
             client_message "Fetched $tgz"
             return


### PR DESCRIPTION
I am trying to install the RabbitMQ cartridge however it is currently failing. Turns out the md5sum command is missing a space between md5 and filename, causing the following error and inability to deploy the cartridge:
Incorrect checksum on fetched rabbitmq-server-generic-unix-3.2.4.tar.gz
md5sum: standard input: no properly formatted MD5 checksum lines found

Line 70 needs to be modified as follows:
ORIG: if echo "$md5 $tgz" | md5sum -c --quiet
NEW : if echo "$md5  $tgz" | md5sum -c --quiet

Also tested directly from command line
Only 1 space fails..
[vagrant@broker ~]$ echo "2c3788f9900b94a083bbbc705c87e2ca rabbitmq-server-generic-unix-3.2.4.tar.gz" | md5sum -c 
md5sum: standard input: no properly formatted MD5 checksum lines found

2 spaces succeeds..
[vagrant@broker ~]$ echo "2c3788f9900b94a083bbbc705c87e2ca  rabbitmq-server-generic-unix-3.2.4.tar.gz" | md5sum -c 
rabbitmq-server-generic-unix-3.2.4.tar.gz: OK
